### PR TITLE
feat(debug): crate feature for easy stringification; fix HTML escaping

### DIFF
--- a/crustrace-core/Cargo.toml
+++ b/crustrace-core/Cargo.toml
@@ -19,3 +19,9 @@ unsynn.workspace = true
 [dev-dependencies]
 insta.workspace = true
 rust-format.workspace = true
+
+[features]
+# Default build has no special formatting — uses Display (`#param_name`)
+default = []
+# Enables Debug (`?#param_name`) formatting of params
+debug = []

--- a/crustrace-core/src/tracer.rs
+++ b/crustrace-core/src/tracer.rs
@@ -320,6 +320,9 @@ fn extract_param_fields(params: &TokenStream) -> TokenStream {
         match &param.value {
             FnParam::Named(named_param) => {
                 let param_name = &named_param.name;
+                #[cfg(feature = "debug")]
+                fields.push(quote!(, #param_name = ?#param_name));
+                #[cfg(not(feature = "debug"))]
                 fields.push(quote!(, #param_name = #param_name));
             }
             FnParam::SelfParam(_) => {
@@ -328,6 +331,9 @@ fn extract_param_fields(params: &TokenStream) -> TokenStream {
             FnParam::Pattern(pattern_param) => {
                 let identifiers = pattern_param.pattern.extract_identifiers();
                 for ident in identifiers {
+                    #[cfg(feature = "debug")]
+                    fields.push(quote!(, #ident = ?#ident));
+                    #[cfg(not(feature = "debug"))]
                     fields.push(quote!(, #ident = #ident));
                 }
             }

--- a/crustrace-mermaid/Cargo.toml
+++ b/crustrace-mermaid/Cargo.toml
@@ -18,3 +18,7 @@ tracing-subscriber = { features = ["registry"], workspace = true }
 crustrace.workspace = true
 insta.workspace = true
 tracing = { features = ["std"], workspace = true }
+
+[features]
+debug = ["crustrace/debug"]
+default = ["debug"]

--- a/crustrace-mermaid/src/visitor.rs
+++ b/crustrace-mermaid/src/visitor.rs
@@ -11,11 +11,11 @@ fn escape_mermaid(input: &str) -> String {
         .replace('"', "&quot;")
         .replace('\'', "&#39;")
         .replace('{', "&#123;")
-        .replace('}', "&#125;")
         .replace('[', "&#91;")
-        .replace(']', "&#93;")
         .replace('|', "&#124;")
 }
+// .replace(']', "&#93;")
+// .replace('}', "&#125;")
 
 /// A [`Visit`] implementation that captures span fields as `(key, value)` pairs.
 ///

--- a/crustrace-mermaid/tests/escaping_slices.rs
+++ b/crustrace-mermaid/tests/escaping_slices.rs
@@ -1,0 +1,30 @@
+// tests/escaping_slices.rs
+#[cfg(test)]
+mod escaping_slices_tests {
+    use crustrace::instrument;
+    use crustrace_mermaid::*;
+    use tracing::subscriber::set_default;
+    use tracing_subscriber::prelude::*;
+
+    /// Function that takes references and slices to reproduce
+    /// the `&[]` / `&["document"]` style output seen in Mermaid.
+    #[instrument]
+    fn slice_cases(name: &str, avro_schema: &[&str], record_stack: &[&str]) {
+        let _ = (name, avro_schema, record_stack);
+    }
+
+    #[test]
+    fn snapshot_slice_cases() {
+        let layer = MermaidLayer::new().without_auto_flush();
+        let subscriber = tracing_subscriber::registry().with(layer.clone());
+        let _guard = set_default(subscriber);
+
+        // Case 1: non-empty slice
+        slice_cases("document", &["field1", "field2"], &["document"]);
+
+        // Case 2: empty slice
+        slice_cases("empty_case", &[], &[]);
+
+        insta::assert_snapshot!(layer.render());
+    }
+}

--- a/crustrace-mermaid/tests/snapshots/escaping__escaping_tests__snapshot_needs_escaping.snap
+++ b/crustrace-mermaid/tests/snapshots/escaping__escaping_tests__snapshot_needs_escaping.snap
@@ -4,8 +4,8 @@ expression: layer.render()
 ---
 flowchart TD
 subgraph Params1[" "]
-  P2_0["json_object = &#123; \&quot;$schema\&quot;: \&quot;https://json-schema.org/draft/2020-12/schema\&quot; &#125;"]:::data
-  P2_1["record_stack = &#91;\&quot;document\&quot;&#93;"]:::data
+  P2_0["json_object = &#123; \&quot;$schema\&quot;: \&quot;https://json-schema.org/draft/2020-12/schema\&quot; }"]:::data
+  P2_1["record_stack = &#91;\&quot;document\&quot;]"]:::data
   P2_0 --- P2_1
 end
 F1["funky()"]:::func

--- a/crustrace-mermaid/tests/snapshots/escaping_slices__escaping_slices_tests__snapshot_slice_cases.snap
+++ b/crustrace-mermaid/tests/snapshots/escaping_slices__escaping_slices_tests__snapshot_slice_cases.snap
@@ -1,0 +1,28 @@
+---
+source: crustrace-mermaid/tests/escaping_slices.rs
+expression: layer.render()
+---
+flowchart TD
+subgraph Params1[" "]
+  P2_0["name = document"]:::data
+  P2_1["avro_schema = &#91;&quot;field1&quot;, &quot;field2&quot;]"]:::data
+  P2_0 --- P2_1
+  P2_2["record_stack = &#91;&quot;document&quot;]"]:::data
+  P2_1 --- P2_2
+end
+F1["slice_cases()"]:::func
+Params1 --> F1
+subgraph Params2[" "]
+  P3_0["name = empty_case"]:::data
+  P3_1["avro_schema = &#91;]"]:::data
+  P3_0 --- P3_1
+  P3_2["record_stack = &#91;]"]:::data
+  P3_1 --- P3_2
+end
+F2["slice_cases()"]:::func
+Params2 --> F2
+
+classDef func fill:#c6f6d5,stroke:#2f855a,stroke-width:2px,color:#22543d;
+classDef data fill:#bee3f8,stroke:#2b6cb0,stroke-width:1.5px,color:#1a365d;
+classDef params fill:none,stroke:#e53e3e,stroke-width:2px,color:#742a2a;
+class Params1,Params2 params;

--- a/crustrace/Cargo.toml
+++ b/crustrace/Cargo.toml
@@ -24,3 +24,7 @@ insta.workspace = true
 rust-format.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[features]
+debug = ["crustrace-core/debug"]
+default = []


### PR DESCRIPTION
- crustrace crate debug feature that turns on `crustrace-core/debug`
- crustrace-core uses debug feature to emit `?` for params and identifiers
- crustrace-mermaid defaults to `crustrace/debug` so that `&[&str]` can be stringified